### PR TITLE
Publish component to ESP registry

### DIFF
--- a/.github/workflows/publish_component.yml
+++ b/.github/workflows/publish_component.yml
@@ -1,0 +1,20 @@
+name: Push component to https://components.espressif.com
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch:
+
+jobs:
+  upload_components:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Upload component to the component registry
+        uses: espressif/upload-components-ci-action@v1
+        with:
+          name: "mcp3002"
+          directories: components/mcp3002
+          namespace: "nopnop2002"
+          api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}

--- a/components/mcp3002/idf_component.yml
+++ b/components/mcp3002/idf_component.yml
@@ -1,0 +1,6 @@
+license: "MIT"
+description: I2C driver for XGZF4000 air flow sensor
+url: https://github.com/nopnop2002/esp-idf-mcp3002/
+issues: https://github.com/nopnop2002/esp-idf-mcp3002/issues
+documentation: https://github.com/nopnop2002/esp-idf-mcp3002/tree/main/README.md
+repository: https://github.com/nopnop2002/esp-idf-mcp3002.git

--- a/components/mcp3002/idf_component.yml
+++ b/components/mcp3002/idf_component.yml
@@ -1,5 +1,5 @@
 license: "MIT"
-description: I2C driver for XGZF4000 air flow sensor
+description: Driver for A/D converter with SPI serial interface
 url: https://github.com/nopnop2002/esp-idf-mcp3002/
 issues: https://github.com/nopnop2002/esp-idf-mcp3002/issues
 documentation: https://github.com/nopnop2002/esp-idf-mcp3002/tree/main/README.md


### PR DESCRIPTION
1. Configured a GitHub action to automatically publish component to ESP registry when there is a new version git tag
2. Wrote the `idf_component.yml` that will be used to display useful info on ESP registry

You will have to add your ESP registry token as a repo secret `IDF_COMPONENT_API_TOKEN`.

For future user using this component, all they have to is add the following line to their `idf_component.yml`:

```yaml
## IDF Component Manager Manifest File
dependencies:
  nopnop2002/esp-idf-mcp3002: "*"
```

This is the [documentation](https://docs.espressif.com/projects/idf-component-manager/en/latest/) of the ESP registry.